### PR TITLE
Types

### DIFF
--- a/machinator-core/ambiata-machinator-core.cabal
+++ b/machinator-core/ambiata-machinator-core.cabal
@@ -1,5 +1,5 @@
 name:                  ambiata-machinator-core
-version:               0.0.1
+version:               1.0.0
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
@@ -15,6 +15,8 @@ library
                        base                            >= 3          && < 5
                      , ambiata-p
                      , ambiata-x-eithert
+                     , containers                      == 0.5.*
+                     , semigroups                      == 0.18.*
                      , transformers                    >= 0.4        && < 0.6
 
   ghc-options:
@@ -25,7 +27,9 @@ library
 
   exposed-modules:
                        Paths_ambiata_machinator_core
+
                        Machinator.Core
+                       Machinator.Core.Data
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/machinator-core/src/Machinator/Core/Data.hs
+++ b/machinator-core/src/Machinator/Core/Data.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Core.Data (
+  -- * Versioning
+    MachinatorVersion (..)
+  , MachinatorFeature (..)
+  , versionFeatures
+  , featureEnabled
+  , featureGuard
+  -- * Datatypes
+  , Name (..)
+  , Type (..)
+  , DataType (..)
+  ) where
+
+
+import           Data.List.NonEmpty  (NonEmpty(..))
+import           Data.Set  (Set)
+import qualified Data.Set as S
+
+import           P
+
+
+-- | The version of machinator in use. This will be reflected in a
+-- mandatory syntax marker and will enable or disable parser and core
+-- language features.
+--
+-- Version should be bumped for every feature addition, feature
+-- removal, or syntax change.
+data MachinatorVersion
+  = MachinatorV1
+  deriving (Eq, Ord, Enum, Show)
+
+-- | Features supported by Machinator at one time or another.
+--
+-- New features should be added to this list freely, but old ones
+-- should never be removed, as we (almost) never want to break
+-- backwards compatibility.
+data MachinatorFeature
+  = HasStrings
+  | HasVariants
+  deriving (Eq, Ord, Enum, Show)
+
+-- | The set of features enabled for a given version.
+versionFeatures :: MachinatorVersion -> Set MachinatorFeature
+versionFeatures mv =
+  case mv of
+    MachinatorV1 ->
+      S.fromList [
+          HasStrings
+        , HasVariants
+        ]
+
+-- | Returns true if the given feature is enabled for the given version.
+featureEnabled :: MachinatorVersion -> MachinatorFeature -> Bool
+featureEnabled v f =
+  S.member f (versionFeatures v)
+
+-- | Succeeds iff the given feature is enabled for the given version.
+featureGuard :: Alternative f => MachinatorVersion -> MachinatorFeature -> f ()
+featureGuard v =
+  guard . featureEnabled v
+
+
+-- -----------------------------------------------------------------------------
+
+-- | The name of a type.
+newtype Name = Name {
+    unName :: Text
+  } deriving (Eq, Ord, Show)
+
+-- | Types.
+data Type
+  = Variable Name
+  | GroundT Ground
+  deriving (Eq, Ord, Show)
+
+-- | Ground types, e.g. platform primitives.
+data Ground
+  = StringT
+  deriving (Eq, Ord, Show)
+
+-- | Declarable datatypes, e.g. sums or records.
+data DataType
+  = Variant (NonEmpty (Name, [Type]))
+  deriving (Eq, Ord, Show)


### PR DESCRIPTION
Initial datatypes.

- Versioning stuff
- Initial types supported: variants (sums) and strings.

Will be following a fairly aggressive churn-minimisation scheme here. The idea is to reliably increment version numbers to mark the addition of new features (or removal). This means each feature is buried under guards/conditional branches, and old versions continue to work always. Can provide an automatic upgrade path for most cases, unless a used feature is deleted. Features here means new types, syntax changes, or semantic changes.

Bikeshedding welcome for type names. Maybe ~~`String8` or~~ `Text` instead of `String`?

! @charleso @olorin @jystic @damncabbage 