### PR TITLE
"data" and "record" field names.

### DIFF
--- a/machinator-core/src/Machinator/Core/Data/Token.hs
+++ b/machinator-core/src/Machinator/Core/Data/Token.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Machinator.Core.Data.Token (
     Token (..)
+  , recordKeyword
+  , dataKeyword
   ) where
 
 
@@ -21,3 +23,12 @@ data Token
   | TTypeSig
   | TRecord
   deriving (Eq, Ord, Show)
+
+
+recordKeyword :: Text
+recordKeyword =
+  "record"
+
+dataKeyword :: Text
+dataKeyword =
+  "data"

--- a/machinator-core/src/Machinator/Core/Lexer.hs
+++ b/machinator-core/src/Machinator/Core/Lexer.hs
@@ -66,8 +66,8 @@ token =
 token' :: Parser (Positioned Token)
 token' =
   withPosition $ M.choice [
-      string "data" *> pure TData
-    , string "record" *> pure TRecord
+      M.try $ string (T.unpack dataKeyword) >> M.spaceChar >> pure TData
+    , M.try $ string (T.unpack recordKeyword) >> M.spaceChar >> pure TRecord
     , string "=" *> pure TEquals
     , string "|" *> pure TChoice
     , string "(" *> pure TLParen

--- a/machinator-core/src/Machinator/Core/Parser.hs
+++ b/machinator-core/src/Machinator/Core/Parser.hs
@@ -141,7 +141,7 @@ record v = do
 
 recordField :: MachinatorVersion -> Parser (Name, Type)
 recordField v = do
-  name <- ident
+  name <- ident <|> dataAsIdent <|> recordAsIdent
   token TTypeSig
   ty <- types v
   pure (name, ty)
@@ -193,6 +193,16 @@ ident :: Parser Name
 ident = do
   TIdent x <- satisfy (\case TIdent _ -> True; _ -> False)
   pure (Name x)
+
+recordAsIdent :: Parser Name
+recordAsIdent = do
+  TRecord <- satisfy (\case TRecord -> True; _ -> False)
+  pure (Name MT.recordKeyword)
+
+dataAsIdent :: Parser Name
+dataAsIdent = do
+  TData <- satisfy (\case TData -> True; _ -> False)
+  pure (Name MT.dataKeyword)
 
 token :: Token -> Parser ()
 token t =

--- a/machinator-core/test/Test/Machinator/Core/Arbitrary.hs
+++ b/machinator-core/test/Test/Machinator/Core/Arbitrary.hs
@@ -18,6 +18,7 @@ import           Disorder.Jack
 
 import           Machinator.Core.Data.Definition
 import           Machinator.Core.Data.Version
+import           Machinator.Core.Data.Token
 
 import           P
 
@@ -114,5 +115,6 @@ genFieldName =
   oneOf [
       fmap Name (elements boats)
     , fmap Name (elements waters)
+    , fmap Name (elements [dataKeyword, recordKeyword])
     , (Name . T.pack) <$> vectorOf 8 (arbitrary `suchThat` Char.isAsciiLower)
     ]


### PR DESCRIPTION
Adds the ability to have "data" or "record" as record field names. Fixes #23.

(Avoids needing a stateful lexer by having the record fields accept TData / TRecord as well as the expected TIdent. This is hacky as hell, yes. ~Sorry~ I am not sorry.)

! @thumphries @sphvn @tmcgilchrist 
/jury approved @sphvn @thumphries @tmcgilchrist